### PR TITLE
fix: optional clear on toString not mandatory

### DIFF
--- a/build/_tests/src/templates/react.js
+++ b/build/_tests/src/templates/react.js
@@ -183,7 +183,7 @@ export default class BaseStyles {
     return this.chain.join('.')
   }
 
-  public toString = (): string => {
+  public toString = (clear: boolean = false): string => {
     if (this.classObjectMode && this.classProps) {
       for (const [key, value] of Object.entries(this.classProps)) {
         if (value) {
@@ -195,7 +195,7 @@ export default class BaseStyles {
       return this.chain[0] || "div";
     }
     const output = this.chain.slice(1).join(" ");
-    this.chain = [this.chain[0]];
+    this.chain = clear ? [this.chain[0]] : this.chain;
     return output;
   };
 

--- a/build/_tests/tailwind-styles.ts
+++ b/build/_tests/tailwind-styles.ts
@@ -172,7 +172,7 @@ export default class BaseStyles {
     return this.chain.join('.')
   }
 
-  public toString = (): string => {
+  public toString = (clear: boolean = false): string => {
     if (this.classObjectMode && this.classProps) {
       for (const [key, value] of Object.entries(this.classProps)) {
         if (value) {
@@ -184,7 +184,7 @@ export default class BaseStyles {
       return this.chain[0] || "div";
     }
     const output = this.chain.slice(1).join(" ");
-    this.chain = [this.chain[0]];
+    this.chain = clear ? [this.chain[0]] : this.chain;
     return output;
   };
 

--- a/build/_tests/tailwind-styles.txt
+++ b/build/_tests/tailwind-styles.txt
@@ -172,7 +172,7 @@ export default class BaseStyles {
     return this.chain.join('.')
   }
 
-  public toString = (): string => {
+  public toString = (clear: boolean = false): string => {
     if (this.classObjectMode && this.classProps) {
       for (const [key, value] of Object.entries(this.classProps)) {
         if (value) {
@@ -184,7 +184,7 @@ export default class BaseStyles {
       return this.chain[0] || "div";
     }
     const output = this.chain.slice(1).join(" ");
-    this.chain = [this.chain[0]];
+    this.chain = clear ? [this.chain[0]] : this.chain;
     return output;
   };
 

--- a/build/main/templates/react.js
+++ b/build/main/templates/react.js
@@ -183,7 +183,7 @@ export default class BaseStyles {
     return this.chain.join('.')
   }
 
-  public toString = (): string => {
+  public toString = (clear: boolean = false): string => {
     if (this.classObjectMode && this.classProps) {
       for (const [key, value] of Object.entries(this.classProps)) {
         if (value) {
@@ -195,7 +195,7 @@ export default class BaseStyles {
       return this.chain[0] || "div";
     }
     const output = this.chain.slice(1).join(" ");
-    this.chain = [this.chain[0]];
+    this.chain = clear ? [this.chain[0]] : this.chain;
     return output;
   };
 

--- a/src/templates/react.ts
+++ b/src/templates/react.ts
@@ -173,7 +173,7 @@ export default class BaseStyles {
     return this.chain.join('.')
   }
 
-  public toString = (): string => {
+  public toString = (clear: boolean = false): string => {
     if (this.classObjectMode && this.classProps) {
       for (const [key, value] of Object.entries(this.classProps)) {
         if (value) {
@@ -185,7 +185,7 @@ export default class BaseStyles {
       return this.chain[0] || "div";
     }
     const output = this.chain.slice(1).join(" ");
-    this.chain = [this.chain[0]];
+    this.chain = clear ? [this.chain[0]] : this.chain;
     return output;
   };
 

--- a/tests/tailwind-styles.txt
+++ b/tests/tailwind-styles.txt
@@ -172,7 +172,7 @@ export default class BaseStyles {
     return this.chain.join('.')
   }
 
-  public toString = (): string => {
+  public toString = (clear: boolean = false): string => {
     if (this.classObjectMode && this.classProps) {
       for (const [key, value] of Object.entries(this.classProps)) {
         if (value) {
@@ -184,7 +184,7 @@ export default class BaseStyles {
       return this.chain[0] || "div";
     }
     const output = this.chain.slice(1).join(" ");
-    this.chain = [this.chain[0]];
+    this.chain = clear ? [this.chain[0]] : this.chain;
     return output;
   };
 


### PR DESCRIPTION
The last change, #40 broke the .fc function in the react template. This fixes it by resetting the behavior or toString and adding an option clear argument to the toString function for when you want to reuse a class and get strings built out of it for classnames