### PR TITLE
fix: add estrella to non-dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-prettier": "^4.2.1",
-    "estrella": "^1.4.1",
     "npm-scripts-info": "^0.3.9",
     "prettier": "2.7.1",
     "rimraf": "^3.0.2",
@@ -94,6 +93,7 @@
   "dependencies": {
     "camel-case": "^4.1.2",
     "commander": "^9.4.0",
+    "estrella": "^1.4.1",
     "normalize-path": "^3.0.0",
     "postcss": "^8.4.14",
     "postcss-import": "^14.1.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Move estrella from devDependencies to dependencies in package.json


* **What is the current behavior?** (You can also link to an open issue here)
pnpm doesn't put the devDeps into the right place


* **What is the new behavior (if this is a feature change)?**
usable with pnpm


* **Other information**:
